### PR TITLE
Removed cache, fixed update parameters

### DIFF
--- a/csv_to_static_groups/csv_to_static_groups.py
+++ b/csv_to_static_groups/csv_to_static_groups.py
@@ -472,8 +472,6 @@ class StaticGroup(object):
                 # Remove current group members that are specified in entities_to_update
                 new_members = list(set(cur_members).difference(set(entities_to_update)))
         if not dryrun:
-            # self.__conn.update_static_group_members(self.uuid, self.name,
-            #                                         self.entity_type, new_members)
             self.__conn.update_static_group_members(self.uuid, new_members, 
                                                     name=self.name, type=self.entity_type)
     @_requires_uuid

--- a/csv_to_static_groups/csv_to_static_groups.py
+++ b/csv_to_static_groups/csv_to_static_groups.py
@@ -561,7 +561,8 @@ class StaticGroup(object):
         uuids = []
         for name in names:
             matches = self.__conn.search_by_name(name, type=self.entity_type,
-                                                 case_sensitive=case_sensitive)
+                                                 case_sensitive=case_sensitive,
+                                                from_cache=True)
             if len(matches) == 0:
                 raise NameMatchError("Unable to find uuid for {}".format(name))
             if len(matches) > 1:
@@ -779,7 +780,8 @@ def main(conn, csv_file, entity_type_header=ENTITY_TYPE_HEADER,
             if member in missing_members:
                 continue
             matches = conn.search_by_name(member, type=group["entity_type"],
-                                          case_sensitive=case_sensitive)
+                                          case_sensitive=case_sensitive,
+                                          from_cache=True)
             if len(matches) == 0:
                 event = (group["name"], "Could not find {} {}".format(group["entity_type"],
                                                                       member))

--- a/csv_to_static_groups/csv_to_static_groups.py
+++ b/csv_to_static_groups/csv_to_static_groups.py
@@ -472,9 +472,10 @@ class StaticGroup(object):
                 # Remove current group members that are specified in entities_to_update
                 new_members = list(set(cur_members).difference(set(entities_to_update)))
         if not dryrun:
-            self.__conn.update_static_group_members(self.uuid, self.name,
-                                                    self.entity_type, new_members)
-
+            # self.__conn.update_static_group_members(self.uuid, self.name,
+            #                                         self.entity_type, new_members)
+            self.__conn.update_static_group_members(self.uuid, new_members, 
+                                                    name=self.name, type=self.entity_type)
     @_requires_uuid
     def remove(self, dryrun=False):
         """Deletes the group from the Turbonomic server.
@@ -562,8 +563,7 @@ class StaticGroup(object):
         uuids = []
         for name in names:
             matches = self.__conn.search_by_name(name, type=self.entity_type,
-                                                 case_sensitive=case_sensitive,
-                                                 from_cache=True)
+                                                 case_sensitive=case_sensitive)
             if len(matches) == 0:
                 raise NameMatchError("Unable to find uuid for {}".format(name))
             if len(matches) > 1:
@@ -781,8 +781,7 @@ def main(conn, csv_file, entity_type_header=ENTITY_TYPE_HEADER,
             if member in missing_members:
                 continue
             matches = conn.search_by_name(member, type=group["entity_type"],
-                                          case_sensitive=case_sensitive,
-                                          from_cache=True)
+                                          case_sensitive=case_sensitive)
             if len(matches) == 0:
                 event = (group["name"], "Could not find {} {}".format(group["entity_type"],
                                                                       member))


### PR DESCRIPTION
Caching in vmtconnect is broken....removed it entirely as it will be deprecated.  Also fixed the arguments for the call to update_static_group_members.  I believe the call used to have all positional arguments, but not has keyword arguments as well. The order and type was resolved.