### PR TITLE
Hotfix for Logging of Duplicate VMs and Documentation of Encoded Creds in Config file

### DIFF
--- a/csv_to_static_groups/csv_to_static_groups.py
+++ b/csv_to_static_groups/csv_to_static_groups.py
@@ -787,7 +787,7 @@ def main(conn, csv_file, entity_type_header=ENTITY_TYPE_HEADER,
                                                                       member))
                 group_changes.track(TRK_MISS_ENTITY, event, warn=True)
             elif len(matches) > 1:
-                msg_str = ("More than one instance of"
+                msg_str = (group["name"], "More than one instance of"
                            " {} {} found".format(group["entity_type"],
                                                   member))
                 group_changes.track(TRK_MISS_ENTITY, msg_str, warn=True)

--- a/docs/source/script_usage.rst
+++ b/docs/source/script_usage.rst
@@ -84,7 +84,7 @@ An example config file could be:
 *sample_config.json*::
 
     {
-      "enccreds":"dXNlcm5hbWU6cGFzc3dvcmQ=",
+      "encoded_creds":"dXNlcm5hbWU6cGFzc3dvcmQ=",
       "target": "some_ip",
       "case_insensitive": true,
       "quiet": true,


### PR DESCRIPTION
Changes:
- Fix for logging when multiple VMs with the same name was found
- Fix documentation for how to define encoded credentials in config file